### PR TITLE
Improve the Release Guide

### DIFF
--- a/resources/meilisearch-release.md
+++ b/resources/meilisearch-release.md
@@ -141,7 +141,7 @@ Instead:
 
 It happens some releases come with impactful bugs in production (e.g. indexation or search issues): we obviously don't wait for the next cycle to fix them and we release a patched version of Meilisearch.
 
-1. Create a new release branch starting from the latest stable Meilisearch release (`latest` or `release-vX.Y.Z`).
+1. Create a new release branch starting from the latest stable Meilisearch release (`latest` git tag or `release-vX.Y.Z` branch).
 
 ```bash
 # Ensure you get all the current tags of the repository

--- a/resources/meilisearch-release.md
+++ b/resources/meilisearch-release.md
@@ -161,7 +161,7 @@ git push -u origin release-vX.Y.Z
 
 5. Follow all the steps in the ["How to do the official release" section](#how-to-do-the-official-release) with the patched version name.
 
-6. Same as the official release, if needed, bring the new commits back from `release-vX.Y.Z` to `main` by merging a PR originating `release-vX.Y.Z` and pointing to `main`.
+6. Same as the official release, if needed, bring the new commits back from `release-vX.Y.Z` to `main` by merging a PR originating `release-vX.Y.Z` and pointing to `main`. If you encounter any merge conflict please [refer to this point](#after-the-release-bring-back-changes-to-main).
 
 ⚠️ <ins>If doing a patch release that should NOT be the `latest` release</s>:
 


### PR DESCRIPTION
This PR improves the release guide. It no longer refers to the `latest` branch and specifies that merge conflicts require a temporary branch.