### PR TITLE
Update the process to update the openAPI file

### DIFF
--- a/issue-templates/update-openapi-issue.md
+++ b/issue-templates/update-openapi-issue.md
@@ -1,9 +1,13 @@
-This issue is about updating the [Open API file](https://github.com/meilisearch/open-api/blob/main/open-api.yaml) related to the Meilisearch release.
+This issue is about updating the [Open API file](https://github.com/meilisearch/open-api/) related to the Meilisearch release.
 
 ## How?
 
-Open a PR on [this repository](https://github.com/meilisearch/open-api) to update the `open-api.yaml` file reflecting changes that have been implemented for the current release.
+- Pull the latest version of the latest rc of Meilisearch `git checkout release-vX.Y.Z; git pull`
+- Starts Meilisearch with the `swagger` feature flag: `cargo run --features swagger`
+- On a browser, open the following URL: http://localhost:7700/scalar
+- Click the « Download openAPI file »
+- Open a PR replacing [this file](https://github.com/meilisearch/open-api/blob/main/open-api.json) with the one downloaded
 
 ## When?
 
-⚠️ This should be done at the end of the sprint, once all the implementations have been done.
+⚠️ This should be done at the end of the pre-release, once all the implementations have been done.


### PR DESCRIPTION
Update the process to update the openAPI file.

The information on how to keep the code updated are in the sprint issues [here](https://github.com/meilisearch/meilisearch/pull/5324)