### PR TITLE
Update v1.15.0.md

### DIFF
--- a/meilisearch-release-changelog/v1.15.0.md
+++ b/meilisearch-release-changelog/v1.15.0.md
@@ -102,6 +102,9 @@ Done by @dureuill in [#5535](https://github.com/meilisearch/meilisearch/pull/553
 * Make sure that passing `MEILI_EXPERIMENTAL_MAX_NUMBER_OF_BATCHED_TASKS` to 0 results in Meilisearch never processing any kind of task. By @irevoire in [#5565](https://github.com/meilisearch/meilisearch/pull/5565)
 * Forbid value `0` for `maxTotalHits` in the index settings by @irevoire in [#5566](https://github.com/meilisearch/meilisearch/pull/5566)
 * No longer reject `documentTemplate`s that use array filters on documents (e.g. `join`) by @dureuill in [#5593](https://github.com/meilisearch/meilisearch/pull/5593)
+* Searchable fields are no more unnindexed when added and removed from the filterable fields by @ManyTheFish in [#5660](https://github.com/meilisearch/meilisearch/pull/5660)
+* Fix chat route missing base URL and Mistral error handling by @Kerollmops in [#5665](https://github.com/meilisearch/meilisearch/pull/5665)
+* Various fixes to embedding regeneration by @dureuill in [#5668](https://github.com/meilisearch/meilisearch/pull/5668)
 
 # Misc
 


### PR DESCRIPTION
* Searchable fields are unnindexed when added and removed from the filterable fields by @ManyTheFish in https://github.com/meilisearch/meilisearch/pull/5660
* Fix chat route missing base URL and Mistral error handling by @Kerollmops in https://github.com/meilisearch/meilisearch/pull/5665
* Various fixes to embedding regeneration by @dureuill in https://github.com/meilisearch/meilisearch/pull/5668